### PR TITLE
Resolves #3: Provide for pre-stop commands for downscaling events

### DIFF
--- a/features/custom-down-script.feature
+++ b/features/custom-down-script.feature
@@ -1,0 +1,32 @@
+Feature: Custom Stop Script
+  So as to ensure that a server that I'm stopping during a downscale
+  event is actually ready to be stopped, I'd like to configure a custom
+  script that will connect to the target server to perform pre-shutdown
+  processes.
+
+  Background:
+    Given I have a scaley config
+    And I have a group named mygroup
+    And I have a script that determines if I should scale up or down
+    And conditions dictate that downscaling is necessary
+    And there is capacity for the group to downscale
+
+  Scenario: No stop script (default behavior)
+    Given my group does not use a custom stop script
+    When I run `scaley scale mygroup`
+    Then the group is scaled down
+    But the stop script is not executed
+
+  Scenario: With a custom stop script
+    Given my group uses a custom stop script that always succeeds
+    When I run `scaley scale mygroup`
+    Then the stop script is executed for each target server
+    And the group is scaled down
+
+  Scenario: With a crashy custom stop script
+    Given my group uses a custom stop script that fails for the first server
+    When I run `scaley scale mygroup`
+    Then the stop script is executed for each target server
+    But a stop script failure is logged for the first server
+    And all applicable servers but the first server are stopped
+

--- a/features/steps/down-script-steps.go
+++ b/features/steps/down-script-steps.go
@@ -1,0 +1,70 @@
+package steps
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ess/jamaica"
+	"github.com/ess/kennel"
+	//"github.com/engineyard/scaley/pkg/basher"
+)
+
+type DownScript struct{}
+
+func (steps *DownScript) StepUp(s kennel.Suite) {
+
+	s.Step(`^the stop script is not executed$`, func() error {
+		if strings.Contains(jamaica.LastCommandOutput(), "STOP_SCRIPT:") {
+			return fmt.Errorf("Expected the stop script to not be run")
+		}
+
+		return nil
+	})
+
+	s.Step(`^the stop script is executed for each target server$`, func() error {
+		output := jamaica.LastCommandOutput()
+
+		expected := len(mygroup.ScalingServers)
+		actual := strings.Count(output, "STOP_SCRIPT")
+
+		if actual != expected {
+			return fmt.Errorf("Expected %d stop script results, got %d", expected, actual)
+		}
+
+		return nil
+	})
+
+	s.Step(`^a stop script failure is logged for the first server$`, func() error {
+		output := jamaica.LastCommandOutput()
+
+		expected := 1
+		actual := strings.Count(output, "STOP_SCRIPT_ERROR")
+
+		if actual != expected {
+			return fmt.Errorf("Expected %d stop script errors, got %d", expected, actual)
+		}
+
+		found := ""
+
+		for _, line := range strings.Split(output, "\n") {
+			if strings.HasPrefix(line, "FAILURE : Group[mygroup]:") {
+				found = line
+			}
+		}
+
+		if len(found) == 0 {
+			return fmt.Errorf("No failure generated")
+		}
+
+		if !strings.Contains(found, mygroup.ScalingServers[0].ID) {
+			return fmt.Errorf("First server not listed in failure")
+		}
+
+		return nil
+	})
+
+}
+
+func init() {
+	kennel.Register(new(DownScript))
+}

--- a/features/steps/locking-steps.go
+++ b/features/steps/locking-steps.go
@@ -26,6 +26,14 @@ func (steps *Locking) StepUp(s kennel.Suite) {
 		)
 	})
 
+	s.Step(`^the group remains locked$`, func() error {
+		if !common.FileExists(common.Locks() + "/mygroup") {
+			return fmt.Errorf("There is no lockfile for the group")
+		}
+
+		return nil
+	})
+
 }
 
 func init() {

--- a/features/steps/scaling-down-steps.go
+++ b/features/steps/scaling-down-steps.go
@@ -5,17 +5,13 @@ import (
 
 	"github.com/ess/jamaica"
 	"github.com/ess/kennel"
-
-	"github.com/engineyard/scaley/pkg/basher"
 )
 
 type ScalingDown struct{}
 
 func (steps *ScalingDown) StepUp(s kennel.Suite) {
 	s.Step(`^conditions dictate that downscaling is necessary$`, func() error {
-		basher.Run = func(string) int {
-			return 1
-		}
+		stubBasher(1)
 
 		return nil
 	})

--- a/features/steps/scaling-up-steps.go
+++ b/features/steps/scaling-up-steps.go
@@ -7,17 +7,13 @@ import (
 	"github.com/ess/jamaica"
 	"github.com/ess/kennel"
 	"github.com/ess/mockable"
-
-	"github.com/engineyard/scaley/pkg/basher"
 )
 
 type ScalingUp struct{}
 
 func (steps *ScalingUp) StepUp(s kennel.Suite) {
 	s.Step(`^conditions dictate that upscaling is necessary$`, func() error {
-		basher.Run = func(string) int {
-			return 2
-		}
+		stubBasher(2)
 
 		return nil
 	})

--- a/features/steps/support.go
+++ b/features/steps/support.go
@@ -1,0 +1,52 @@
+package steps
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/engineyard/scaley/pkg/basher"
+	"github.com/engineyard/scaley/pkg/group"
+)
+
+var mygroup *group.Group
+
+func generateGroup() *group.Group {
+	mygroup = &group.Group{
+		Name: "mygroup",
+		ScalingServers: []*group.Server{
+			&group.Server{ID: "i-00000001"},
+			&group.Server{ID: "i-00000002"},
+		},
+		ScalingScript: "/bin/decider",
+		Strategy:      "legion",
+	}
+
+	return mygroup
+}
+
+func stubBasher(direction int) {
+	basher.Run = func(command string) int {
+		if command == "/bin/decider" {
+			return direction
+		}
+
+		if strings.HasPrefix(command, "stop_script") {
+			base := "STOP_SCRIPT"
+			contexts := strings.Split(command, " ")
+
+			switch contexts[0] {
+			case "stop_script_good":
+				fmt.Println(base+":", command)
+			case "stop_script_bad":
+				if contexts[1] == "server0" {
+					fmt.Println(base+"_ERROR:", command)
+					return 1
+				} else {
+					fmt.Println(base+":", command)
+				}
+			}
+		}
+
+		return 0
+	}
+}

--- a/pkg/basher/basher.go
+++ b/pkg/basher/basher.go
@@ -5,22 +5,16 @@ import (
 	"syscall"
 )
 
-var Run func(command string) int
+var Run = func(command string) int {
+	cmd := exec.Command("bash", "-c", command)
+	var waitStatus syscall.WaitStatus
 
-func init() {
-	if Run == nil {
-		Run = func(command string) int {
-			cmd := exec.Command("bash", "-c", command)
-			var waitStatus syscall.WaitStatus
-
-			if err := cmd.Run(); err != nil {
-				if exitError, ok := err.(*exec.ExitError); ok {
-					waitStatus = exitError.Sys().(syscall.WaitStatus)
-					return waitStatus.ExitStatus()
-				}
-			}
-
-			return 0
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			waitStatus = exitError.Sys().(syscall.WaitStatus)
+			return waitStatus.ExitStatus()
 		}
 	}
+
+	return 0
 }

--- a/pkg/basher/basher.go
+++ b/pkg/basher/basher.go
@@ -5,16 +5,23 @@ import (
 	"syscall"
 )
 
-var Run = func(command string) int {
-	cmd := exec.Command("bash", "-c", command)
-	var waitStatus syscall.WaitStatus
+var Run func(command string) int
 
-	if err := cmd.Run(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			waitStatus = exitError.Sys().(syscall.WaitStatus)
-			return waitStatus.ExitStatus()
+func init() {
+	if Run == nil {
+		Run = func(command string) int {
+			panic("like a motherfucker")
+			cmd := exec.Command("bash", "-c", command)
+			var waitStatus syscall.WaitStatus
+
+			if err := cmd.Run(); err != nil {
+				if exitError, ok := err.(*exec.ExitError); ok {
+					waitStatus = exitError.Sys().(syscall.WaitStatus)
+					return waitStatus.ExitStatus()
+				}
+			}
+
+			return 0
 		}
 	}
-
-	return 0
 }

--- a/pkg/basher/basher.go
+++ b/pkg/basher/basher.go
@@ -10,7 +10,6 @@ var Run func(command string) int
 func init() {
 	if Run == nil {
 		Run = func(command string) int {
-			panic("like a motherfucker")
 			cmd := exec.Command("bash", "-c", command)
 			var waitStatus syscall.WaitStatus
 

--- a/pkg/group/group.go
+++ b/pkg/group/group.go
@@ -16,6 +16,7 @@ type Group struct {
 	PermanentServers []*Server `yaml:"permanent_servers"`
 	ScalingServers   []*Server `yaml:"scaling_servers"`
 	ScalingScript    string    `yaml:"scaling_script"`
+	StopScript       string    `yaml:"stop_script"`
 	Strategy         string    `yaml:"strategy"`
 	Environment      *environments.Model
 }

--- a/pkg/group/scaling.go
+++ b/pkg/group/scaling.go
@@ -131,3 +131,7 @@ func (g *Group) candidatesForDownscale() []scaler.Server {
 func (g *Group) ScalingStrategy() string {
 	return g.Strategy
 }
+
+func (g *Group) PreStop() string {
+	return g.StopScript
+}

--- a/pkg/group/server.go
+++ b/pkg/group/server.go
@@ -16,3 +16,7 @@ func (s *Server) AmazonID() string {
 func (s *Server) EngineYardID() int {
 	return s.Instance.ID
 }
+
+func (s *Server) Hostname() string {
+	return s.Instance.PrivateHostname
+}

--- a/pkg/scaler/individual.go
+++ b/pkg/scaler/individual.go
@@ -40,7 +40,7 @@ func (scaler *individual) Downscale() error {
 
 	candidate := candidates[0]
 
-	if err := stopServer(candidate, scaler.api); err != nil {
+	if err := stopServer(candidate, scaler.api, scaler.group.PreStop()); err != nil {
 		return fmt.Errorf(downFail, candidate.AmazonID())
 	}
 

--- a/pkg/scaler/legion.go
+++ b/pkg/scaler/legion.go
@@ -38,7 +38,7 @@ func (scaler *legion) Downscale() error {
 	failures := make([]string, 0)
 
 	for _, s := range scaler.group.Candidates("down") {
-		err := stopServer(s, scaler.api)
+		err := stopServer(s, scaler.api, scaler.group.PreStop())
 		if err != nil {
 			failures = append(failures, s.AmazonID())
 		}


### PR DESCRIPTION
This addresses #3 by adding a "stop_script" group configuration setting.

This stop script is run on the same computer as scaley itself and receives the hostname of the server that is being downscaled. If the script does not exit cleanly, we **DO NOT** proceed with shutting down the server.