### PR TITLE
Report server details for both success and failure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Engine Yard, Inc.
+   Copyright 2019 Engine Yard, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmd/scaley/commands/root.go
+++ b/cmd/scaley/commands/root.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 Engine Yard, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package commands
 
 import (
@@ -54,3 +40,17 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 	}
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/cmd/scaley/commands/scale.go
+++ b/cmd/scaley/commands/scale.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 Engine Yard, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package commands
 
 import (
@@ -105,3 +91,17 @@ var services = func() *scaley.Services {
 var api string
 var reportingURL string
 var token string
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/cmd/scaley/main.go
+++ b/cmd/scaley/main.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 Engine Yard, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package main
 
 import (
@@ -25,3 +11,17 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/internal/steps/log-steps.go
+++ b/internal/steps/log-steps.go
@@ -16,11 +16,11 @@ func (steps *LogSteps) StepUp(s kennel.Suite) {
 		found := 0
 		output := jamaica.LastCommandStdout()
 
-		if strings.Contains(output, "FAILURE : Group[mygroup]: Could not be scaled up - Errors occurred while starting these servers, please contact support: ") {
+		if strings.Contains(output, "FAILURE : Group[mygroup]: Could not be scaled up - Errors occurred while starting servers, please contact support. ") {
 			found += 1
 		}
 
-		if strings.Contains(output, "FAILURE : Group[mygroup]: Could not be scaled down - Errors occurred while stopping these servers, please contact support: ") {
+		if strings.Contains(output, "FAILURE : Group[mygroup]: Could not be scaled down - Errors occurred while stopping servers, please contact support. ") {
 			found += 1
 		}
 

--- a/pkg/scaley/bash/exec_service.go
+++ b/pkg/scaley/bash/exec_service.go
@@ -34,3 +34,17 @@ var Run = func(command string) int {
 
 	return 0
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/direction.go
+++ b/pkg/scaley/direction.go
@@ -34,3 +34,17 @@ const (
 	// Up indicates that the group should be scaled up.
 	Up
 )
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/errors.go
+++ b/pkg/scaley/errors.go
@@ -173,3 +173,17 @@ func (e ChefFailure) Error() string {
 		e.Group.Name,
 	)
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/eycore/environment_service.go
+++ b/pkg/scaley/eycore/environment_service.go
@@ -71,3 +71,17 @@ func (service *EnvironmentService) Configure(env *scaley.Environment) error {
 
 	return nil
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/eycore/eycore.go
+++ b/pkg/scaley/eycore/eycore.go
@@ -79,3 +79,17 @@ func waitFor(req *eygo.Request) (*eygo.Request, error) {
 
 	return ret, nil
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/eycore/server_service.go
+++ b/pkg/scaley/eycore/server_service.go
@@ -94,3 +94,17 @@ func (service *ServerService) Stop(server *scaley.Server) error {
 
 	return nil
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/finalize.go
+++ b/pkg/scaley/finalize.go
@@ -54,14 +54,14 @@ func finalizeFailure(result dry.Result) error {
 			action = "stopping"
 		}
 
-		failures := make([]string, 0)
-		for _, f := range event.Failed {
-			failures = append(failures, f.ProvisionedID)
-		}
-
 		log.Failure(
 			group,
-			fmt.Sprintf("Could not be scaled %s - Errors occurred while %s these servers, please contact support: %s", direction, action, strings.Join(failures, ", ")),
+			fmt.Sprintf(
+				"Could not be scaled %s - Errors occurred while %s servers, please contact support. %s",
+				direction,
+				action,
+				failureDetails(event.Scaled, event.Failed),
+			),
 		)
 
 		lerr := locker.Unlock(group)
@@ -76,7 +76,12 @@ func finalizeFailure(result dry.Result) error {
 	if chefFailureDetected(err) {
 		log.Failure(
 			group,
-			fmt.Sprintf("Could not be scaled %s - A Chef error occurred while %sscaling the group. Please contact support.", direction, direction),
+			fmt.Sprintf(
+				"Could not be scaled %s - A Chef error occurred while %sscaling the group. Please contact support. %s",
+				direction,
+				direction,
+				failureDetails(event.Scaled, event.Failed),
+			),
 		)
 	}
 
@@ -124,11 +129,18 @@ func finalizeSuccess(result dry.Result) error {
 	}
 
 	// log success
+	scaled := make([]string, 0)
+
+	for _, server := range event.Scaled {
+		scaled = append(scaled, server.ProvisionedID)
+	}
+
 	log.Success(
 		group,
 		fmt.Sprintf(
-			"Successfully scaled %s",
+			"Successfully scaled %s. Servers affected: %s",
 			event.Direction.String(),
+			strings.Join(scaled, ", "),
 		),
 	)
 
@@ -137,4 +149,34 @@ func finalizeSuccess(result dry.Result) error {
 
 func logUnlockFailure(log LogService, group *Group) {
 	log.Failure(group, "Cannot unlock the group. Please contact support.")
+}
+
+func failureDetails(scaled []*Server, failed []*Server) string {
+	failedIDs := make([]string, 0)
+	for _, f := range failed {
+		failedIDs = append(failedIDs, f.ProvisionedID)
+	}
+
+	scaledIDs := make([]string, 0)
+	for _, s := range scaled {
+		scaledIDs = append(scaledIDs, s.ProvisionedID)
+	}
+
+	parts := make([]string, 0)
+
+	if len(failedIDs) > 0 {
+		parts = append(
+			parts,
+			"(Failed to start/stop: "+strings.Join(failedIDs, ", ")+")",
+		)
+	}
+
+	if len(scaledIDs) > 0 {
+		parts = append(
+			parts,
+			"(Successfully started/stopped: "+strings.Join(scaledIDs, ", ")+")",
+		)
+	}
+
+	return strings.Join(parts, " ")
 }

--- a/pkg/scaley/finalize.go
+++ b/pkg/scaley/finalize.go
@@ -180,3 +180,17 @@ func failureDetails(scaled []*Server, failed []*Server) string {
 
 	return strings.Join(parts, " ")
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/fs/fs.go
+++ b/pkg/scaley/fs/fs.go
@@ -41,3 +41,17 @@ var CreateDir = func(path string) {
 		}
 	}
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/fs/group_service.go
+++ b/pkg/scaley/fs/group_service.go
@@ -46,3 +46,17 @@ func (s *GroupService) Get(name string) (*scaley.Group, error) {
 
 	return g, nil
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/fs/locations.go
+++ b/pkg/scaley/fs/locations.go
@@ -47,3 +47,17 @@ func dataDir() string {
 	CreateDir(path)
 	return path
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/fs/lock_service.go
+++ b/pkg/scaley/fs/lock_service.go
@@ -54,3 +54,17 @@ func (service LockService) Locked(group *scaley.Group) bool {
 func lockfile(group *scaley.Group) string {
 	return fmt.Sprintf("%s/%s", Locks(), group.Name)
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/fs/scaling_script_service.go
+++ b/pkg/scaley/fs/scaling_script_service.go
@@ -14,3 +14,17 @@ func NewScalingScriptService() *ScalingScriptService {
 func (service *ScalingScriptService) Exists(path string) bool {
 	return FileExists(path)
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/http/log_service.go
+++ b/pkg/scaley/http/log_service.go
@@ -51,3 +51,17 @@ func (service *LogService) Failure(group *scaley.Group, message string) {
 func normalize(group *scaley.Group, message string) string {
 	return fmt.Sprintf("Group[%s]: %s", group.Name, message)
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/http/notify.go
+++ b/pkg/scaley/http/notify.go
@@ -27,3 +27,17 @@ func notify(url string, level int, message string) {
 		}
 	}
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/http/payload.go
+++ b/pkg/scaley/http/payload.go
@@ -59,3 +59,17 @@ func currentValue(level int) string {
 
 	return "0.0"
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/scale.go
+++ b/pkg/scaley/scale.go
@@ -251,3 +251,17 @@ func configureEnvironment(input dry.Value) dry.Result {
 
 	return dry.Success(event)
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/scaley.go
+++ b/pkg/scaley/scaley.go
@@ -25,3 +25,17 @@ type Environment struct {
 	ID   string
 	Name string
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/scaling_event.go
+++ b/pkg/scaley/scaling_event.go
@@ -25,3 +25,17 @@ func eventify(input dry.Value) *ScalingEvent {
 
 	return e
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/services.go
+++ b/pkg/scaley/services.go
@@ -60,3 +60,17 @@ type LogService interface {
 	Failure(*Group, string)
 	Success(*Group, string)
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/severity.go
+++ b/pkg/scaley/severity.go
@@ -11,3 +11,17 @@ const (
 	// Failure is used for failure logs.
 	Failure
 )
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/pkg/scaley/strategy.go
+++ b/pkg/scaley/strategy.go
@@ -45,3 +45,17 @@ func normalizedStrategyName(name string) string {
 		),
 	)
 }
+
+// Copyright © 2019 Engine Yard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.


### PR DESCRIPTION
* Successful scaling events now notify the list of servers that
  were affected by the event.
* Failed scaling events now list both the servers that failed to
  change state as well as those with successful state changes.

Closes #24 