### PR TITLE
Optionally ignore stop script errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ When one runs `scaley scale groupname`, the "groupname" group is scaled via the 
 During each run, Scaley executes the Scaling Script associated with the Group and does the following based on the result of that run:
 
 * If an upscale is desired, attempt to scale the group up with the group's desired strategy. Log any scaling errors as critical errors, and log a lack of capacity in the group as a warning.
-* If a downscale is desired, attempt to scale the group down with the group's desired strategy (and optional stop script). Log any scaling errors as critical errors.
+* If a downscale is desired, attempt to scale the group down with the group's desired strategy (and optional stop script). Log any scaling errors as critical errors. Of particular note, unless the group is configured with `ignore_stop_script_errors: true`, a failure in the stop script execution will be considered a scaling failure.
 * If no change is desired, do not attempt to scale the group.
 
 # History #

--- a/features/scale/custom-down-script.feature
+++ b/features/scale/custom-down-script.feature
@@ -27,6 +27,7 @@ Feature: Custom Stop Script
     And it exits successfully
     And the group is unlocked
 
+    @failure
   Scenario: With a crashy custom stop script
     Given my group uses a custom stop script that fails for the first server
     When I run `scaley scale mygroup`
@@ -36,3 +37,11 @@ Feature: Custom Stop Script
     And it exits with an error
     And the group is unlocked
 
+  Scenario: Ingoring stop script errors
+    Given my group uses a custom stop script that fails for the first server
+    But my group is configured to ignore stop script errors
+    When I run `scaley scale mygroup`
+    Then the stop script is executed for each target server
+    And the group is scaled down
+    And it exits successfully
+    And the group is unlocked

--- a/internal/steps/group-steps.go
+++ b/internal/steps/group-steps.go
@@ -172,6 +172,12 @@ func (steps *Group) StepUp(s kennel.Suite) {
 		return steps.writeGroup()
 	})
 
+	s.Step(`^my group is configured to ignore stop script errors$`, func() error {
+		steps.model.IgnoreStopScriptErrors = true
+
+		return steps.writeGroup()
+	})
+
 	s.Step(`^my group is configured to use the individual strategy$`, func() error {
 		steps.model = generateGroup("individual")
 

--- a/pkg/scaley/errors.go
+++ b/pkg/scaley/errors.go
@@ -79,7 +79,7 @@ type NoViableCandidates struct {
 func (e NoViableCandidates) Error() string {
 	return fmt.Sprintf(
 		"%s has no viable candidates to scale %s",
-		e.Group,
+		e.Group.Name,
 		e.Direction,
 	)
 }

--- a/pkg/scaley/scale.go
+++ b/pkg/scaley/scale.go
@@ -228,8 +228,12 @@ func scaleCandidateDown(candidate *Server, event *ScalingEvent) error {
 	if len(stopscript) > 0 {
 		command := fmt.Sprintf("%s %s", stopscript, candidate.Hostname)
 
-		if event.Services.Runner.Run(command) != 0 {
-			return fmt.Errorf("stop script failure")
+		ssr := event.Services.Runner.Run(command)
+
+		if !event.Group.IgnoreStopScriptErrors {
+			if ssr != 0 {
+				return fmt.Errorf("stop script failure")
+			}
 		}
 	}
 

--- a/pkg/scaley/scaley.go
+++ b/pkg/scaley/scaley.go
@@ -4,11 +4,12 @@ package scaley
 
 // Group is a representation of a scaling group.
 type Group struct {
-	Name           string   `yaml:"name"`
-	ScalingServers []string `yaml:"scaling_servers"`
-	ScalingScript  string   `yaml:"scaling_script"`
-	StopScript     string   `yaml:"stop_script"`
-	Strategy       string   `yaml:"strategy"`
+	Name                   string   `yaml:"name"`
+	ScalingServers         []string `yaml:"scaling_servers"`
+	ScalingScript          string   `yaml:"scaling_script"`
+	StopScript             string   `yaml:"stop_script"`
+	IgnoreStopScriptErrors bool     `yaml:"ignore_stop_script_errors"`
+	Strategy               string   `yaml:"strategy"`
 }
 
 // Server is a representation of a server in an Engine Yard Cloud environment.


### PR DESCRIPTION
This PR adds a new item to the group config: `ignore_stop_script_errors`, which is a boolean that defaults to `false`.

That is, the default behavior is to treat a stop script failure as a scaling failure, but this changes if you do the following in your group file:

```yaml
stop_script: /path/to/some/crashy/script
ignore_stop_script_errors: true
```
With the above, in the event that the stop script fails for a server, scaley just shrugs and moves forward with the process of scaling that server down.

Closes #22 