### PR TITLE
Feature/fix server lookups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/DATA-DOG/godog v0.7.13
+	github.com/ess/debuggable v1.0.0
 	github.com/ess/dry v1.0.0
-	github.com/ess/eygo v0.3.1
+	github.com/ess/eygo v0.3.6
 	github.com/ess/jamaica v1.0.3
 	github.com/ess/kennel v0.0.4
 	github.com/ess/mockable v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,12 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ess/debuggable v1.0.0 h1:tMxRJ5kercQkPGa8uvtBou9gisaFgK+iURNSTFEjzdA=
+github.com/ess/debuggable v1.0.0/go.mod h1:xffN9MmBxD0x0wMIXAT7R+jUNZt33fV2v1d9i8v6aS8=
 github.com/ess/dry v1.0.0 h1:vL2Cw5DGpI9+Ph/Yc/9bvgIIfYUkVYf448Uk7OfiHUE=
 github.com/ess/dry v1.0.0/go.mod h1:ONBO4CYuC1L0q8c1pnDJtQwF9H3ZZxKmJtVBVkrU8h0=
-github.com/ess/eygo v0.3.1 h1:u2eGIfm+V6VB7fifMGe/6C+jDVz9Uqs9hFM9c66joOU=
-github.com/ess/eygo v0.3.1/go.mod h1:mZcibSJ62+pL8CKVfv6aQTlrY5WJwmbcPMiVwvOkK0s=
+github.com/ess/eygo v0.3.6 h1:A0uiK00HmSxgEL9kFLb3qRDpbAdDhgUUTkxh3rSKACo=
+github.com/ess/eygo v0.3.6/go.mod h1:oo+w91pdvVq/IcvIfbjBvsmIWoo/+9TQU7oHd9Nl/Z4=
 github.com/ess/jamaica v1.0.3 h1:R3XizHAqM+JLWsoJvQ/OTIHpzfadsZGEO/bbfuovbXI=
 github.com/ess/jamaica v1.0.3/go.mod h1:7FXZfv7Rp8EDwCrjZx+BahXozz5EUklcBEGy5ucbxRY=
 github.com/ess/kennel v0.0.4 h1:hiWVATvsnCREmKS14/wt5ya5M9nq9+ehoRtBHXd62FQ=

--- a/pkg/scaley/eycore/environment_service.go
+++ b/pkg/scaley/eycore/environment_service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/ess/debuggable"
 	"github.com/ess/eygo"
 
 	"github.com/engineyard/scaley/pkg/scaley"
@@ -62,6 +63,9 @@ func (service *EnvironmentService) Configure(env *scaley.Environment) error {
 
 	req, err = waitFor(req)
 	if err != nil {
+		if debuggable.Enabled() {
+			fmt.Println("[scaley debug] waitFor returned an error:", err)
+		}
 		return err
 	}
 

--- a/pkg/scaley/eycore/eycore.go
+++ b/pkg/scaley/eycore/eycore.go
@@ -2,8 +2,10 @@ package eycore
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
+	"github.com/ess/debuggable"
 	"github.com/ess/eygo"
 	"github.com/ess/eygo/http"
 )
@@ -16,7 +18,12 @@ var Driver eygo.Driver
 // Driver to interact with the EY Core API at that url with the given token.
 func Setup(baseURL string, token string) {
 	if Driver == nil {
-		Driver, _ = http.NewDriver(baseURL, token)
+		d, err := http.NewDriver(baseURL, token)
+		if err != nil {
+			panic("Couldn't set up the API driver: " + err.Error())
+		}
+
+		Driver = d
 	}
 }
 
@@ -31,6 +38,9 @@ func serverReq(path string) (*eygo.Request, error) {
 
 		err := json.Unmarshal(data, &wrapper)
 		if err != nil {
+			if debuggable.Enabled() {
+				fmt.Println("[scaley debug] Couldn't unmarshal the request:", err)
+			}
 			return nil, err
 		}
 
@@ -51,6 +61,10 @@ func rawPost(path string) (*eygo.Request, error) {
 
 		err := json.Unmarshal(data, &wrapper)
 		if err != nil {
+			if debuggable.Enabled() {
+				fmt.Println("[scaley debug] Couldn't unmarshal the POST request:", err)
+			}
+
 			return nil, err
 		}
 

--- a/pkg/scaley/finalize.go
+++ b/pkg/scaley/finalize.go
@@ -24,14 +24,20 @@ func finalizeFailure(result dry.Result) error {
 	log := event.Services.Log
 	locker := event.Services.Locker
 	err := event.Error
+	group := event.Group
 
 	// handle no-op
 	if noOpDetected(err) {
-		// do nothing, and return no error
+		// unlock the group
+		lerr := locker.Unlock(group)
+		if lerr != nil {
+			logUnlockFailure(log, group)
+		}
+
+		// return no error
 		return nil
 	}
 
-	group := event.Group
 	direction := strings.ToLower(event.Direction.String())
 
 	// handle insufficient capacity

--- a/pkg/scaley/scale.go
+++ b/pkg/scaley/scale.go
@@ -3,6 +3,7 @@ package scaley
 import (
 	"fmt"
 
+	"github.com/ess/debuggable"
 	"github.com/ess/dry"
 )
 
@@ -198,6 +199,9 @@ func scaleCandidates(input dry.Value) dry.Result {
 	for _, server := range toScale {
 		err := method(server, event)
 		if err != nil {
+			if debuggable.Enabled() {
+				fmt.Println("[scaley debug] server state change error:", err)
+			}
 			event.Failed = append(event.Failed, server)
 		} else {
 			event.Scaled = append(event.Scaled, server)


### PR DESCRIPTION
The newest eygo version provides a lot more information for each of the items that it retrieves from the API, but since the data presented by the EY Core API is not consistent, it caused some unforeseen issues.

Since eygo has been updated, so has scaley.