### PR TITLE
Feature/unlock on insufficient capacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ builds/
 coverage.out
 .quality
 .coverage
+goreporter/

--- a/features/scale/scaling-down.feature
+++ b/features/scale/scaling-down.feature
@@ -22,6 +22,7 @@ Feature: Scaling Down
     When I run `scaley scale mygroup`
     Then no changes are made
     And no messages are logged
+    And the group is unlocked
 
     Examples:
       | Strategy    |

--- a/features/scale/scaling-up.feature
+++ b/features/scale/scaling-up.feature
@@ -23,6 +23,7 @@ Feature: Scaling Up
     Then a warning is logged regarding the insufficient capacity
     And it exits successfully
     But no changes are made
+    And the group is unlocked
 
     Examples:
       | Strategy    |

--- a/pkg/scaley/finalize.go
+++ b/pkg/scaley/finalize.go
@@ -49,6 +49,11 @@ func finalizeFailure(result dry.Result) error {
 			)
 		}
 
+		lerr := locker.Unlock(group)
+		if lerr != nil {
+			logUnlockFailure(log, group)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Closes #33 

If a scaling event fails due to insufficient capacity, that's a softer failure than an actual start/stop or chef failure, so it does not leave the group locked.