### PR TITLE
Log locked group failures

### DIFF
--- a/features/scale/scaling-down.feature
+++ b/features/scale/scaling-down.feature
@@ -35,7 +35,9 @@ Feature: Scaling Down
     And there is capacity for the group to downscale
     When I run `scaley scale mygroup`
     Then it exits with an error
-    And no changes are made
+    And a locking failure is logged
+    But no changes are made
+    And the group remains locked
 
     @failure
   Scenario Outline: Stop server yields an invalid API response

--- a/features/scale/scaling-up.feature
+++ b/features/scale/scaling-up.feature
@@ -36,7 +36,9 @@ Feature: Scaling Up
     And there is capacity for the group to upscale
     When I run `scaley scale mygroup`
     Then it exits with an error
-    And no changes are made
+    And a locking failure is logged
+    But no changes are made
+    And the group remains locked
 
     @failure
   Scenario Outline: Start server yields an invalid API response

--- a/internal/steps/log-steps.go
+++ b/internal/steps/log-steps.go
@@ -50,6 +50,16 @@ func (steps *LogSteps) StepUp(s kennel.Suite) {
 		return nil
 	})
 
+	s.Step(`^a locking failure is logged$`, func() error {
+		output := jamaica.LastCommandStdout()
+
+		if strings.Contains(output, "FAILURE : Group[mygroup]: Cannot be scaled - Another scaley process has locked the group and may still be in-progress") {
+			return nil
+		}
+
+		return fmt.Errorf("Locking failure not found")
+	})
+
 	s.BeforeSuite(func() {
 		mockable.Enable()
 	})

--- a/pkg/scaley/finalize.go
+++ b/pkg/scaley/finalize.go
@@ -38,6 +38,17 @@ func finalizeFailure(result dry.Result) error {
 		return nil
 	}
 
+	// handle a locked group
+	if groupLockDetected(err) {
+		log.Failure(
+			group,
+			"Cannot be scaled - Another scaley process has locked the group and may still be in-progress",
+		)
+
+		// pass the error on through
+		return err
+	}
+
 	direction := strings.ToLower(event.Direction.String())
 
 	// handle insufficient capacity
@@ -103,6 +114,12 @@ func finalizeFailure(result dry.Result) error {
 
 func noOpDetected(err error) bool {
 	_, c1 := err.(NoChangeRequired)
+
+	return c1
+}
+
+func groupLockDetected(err error) bool {
+	_, c1 := err.(GroupIsLocked)
 
 	return c1
 }


### PR DESCRIPTION
Resolves #36 

When scaley is run on a group that is already locked, we already error out without making any changes. This change takes that a step further by generating a CRITICAL alert for the environment to advise as to what happened.