### PR TITLE
Optionally unlock on failure

### DIFF
--- a/features/scale/scaling-down.feature
+++ b/features/scale/scaling-down.feature
@@ -98,3 +98,20 @@ Feature: Scaling Down
       | Strategy    |
       | individual  |
       | legion      |
+
+    @failure
+  Scenario Outline: Chef run failure (locking_on_failure disabled)
+    Given my group is configured to use the <Strategy> strategy
+    And my group is configured to unlock on failures
+    And there is capacity for the group to downscale
+    But the environment cannot run chef successfully
+    When I run `scaley scale mygroup`
+    Then it exits with an error
+    And a chef failure is logged
+    But the group is unlocked
+
+    Examples:
+      | Strategy    |
+      | individual  |
+      | legion      |
+

--- a/features/scale/scaling-up.feature
+++ b/features/scale/scaling-up.feature
@@ -99,3 +99,20 @@ Feature: Scaling Up
       | Strategy    |
       | individual  |
       | legion      |
+
+    @failure
+  Scenario Outline: Chef run failure (locking_on_failure disabled)
+    Given my group is configured to use the <Strategy> strategy
+    And my group is configured to unlock on failures
+    And there is capacity for the group to upscale
+    But the environment cannot run chef successfully
+    When I run `scaley scale mygroup`
+    Then it exits with an error
+    And a chef failure is logged
+    But the group is unlocked
+
+    Examples:
+      | Strategy    |
+      | individual  |
+      | legion      |
+

--- a/internal/steps/group-steps.go
+++ b/internal/steps/group-steps.go
@@ -178,6 +178,12 @@ func (steps *Group) StepUp(s kennel.Suite) {
 		return steps.writeGroup()
 	})
 
+	s.Step(`^my group is configured to unlock on failures$`, func() error {
+		steps.model.UnlockOnFailure = true
+
+		return steps.writeGroup()
+	})
+
 	s.Step(`^my group is configured to use the individual strategy$`, func() error {
 		steps.model = generateGroup("individual")
 

--- a/pkg/scaley/finalize.go
+++ b/pkg/scaley/finalize.go
@@ -105,6 +105,13 @@ func finalizeFailure(result dry.Result) error {
 				failureDetails(event.Scaled, event.Failed),
 			),
 		)
+
+		if group.UnlockOnFailure {
+			lerr := locker.Unlock(group)
+			if lerr != nil {
+				logUnlockFailure(log, group)
+			}
+		}
 	}
 
 	// pass all other errors upstream

--- a/pkg/scaley/scaley.go
+++ b/pkg/scaley/scaley.go
@@ -9,6 +9,7 @@ type Group struct {
 	ScalingScript          string   `yaml:"scaling_script"`
 	StopScript             string   `yaml:"stop_script"`
 	IgnoreStopScriptErrors bool     `yaml:"ignore_stop_script_errors"`
+	UnlockOnFailure        bool     `yaml:"unlock_on_failure"`
 	Strategy               string   `yaml:"strategy"`
 }
 


### PR DESCRIPTION
Resolves #38 

This change enables a user to configure a group such that even in scenarios where a failure would leave the group in a locked state, the lock is cleared.

As it were, the only failures that leave the group locked are chef-related issues.